### PR TITLE
Cleaning the Coach ViewModel when the app navigate to New Coach Page.

### DIFF
--- a/src/View.Elm
+++ b/src/View.Elm
@@ -51,7 +51,12 @@ coachesEditView address model coachId =
 
 coachesNewView : Signal.Address Action -> AppModel -> Html.Html
 coachesNewView address model =
-  CoachesEditView.view (Signal.forwardTo address CoachesEditAction) model.coachVM
+  let
+    updatedCoachVM =
+      { model | coachVM = CoachesEditModels.initialViewModel }
+
+  in
+    CoachesEditView.view (Signal.forwardTo address CoachesEditAction) updatedCoachVM.coachVM
 
 
 coachesSearchView : Signal.Address Action -> AppModel -> Html.Html


### PR DESCRIPTION
Not show dirt in `New Coach Page` when before to navigate to it was showing an existent Coach.
